### PR TITLE
fix: correct typo in GitLab log message

### DIFF
--- a/gitlab.js
+++ b/gitlab.js
@@ -34,7 +34,7 @@ async function findBranchesAndCreateMRs(ticket) {
       const filteredMRList = existingMRs.filter(mr => mr.project_id == projectId && mr.source_branch.includes(branch.name) && mr.target_branch === 'release');
 
       if (filteredMRList.length > 0) {
-        logger.info(`⚠️ el MR ya existe para el branch ${branch.name} en el pryoecto ${projectId}`);
+        logger.info(`⚠️ el MR ya existe para el branch ${branch.name} en el proyecto ${projectId}`);
         continue;
       }
 


### PR DESCRIPTION
## Summary
- fix a typo in the GitLab log message

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e1304bec48328b0f5e0bb4b36b90f