### PR TITLE
Add AGENTS guidelines for project roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS
+
+This file outlines expectations for the different roles involved in this project.
+
+## Developers
+- Follow JavaScript ES module conventions and keep code readable.
+- Run `npm test` and lint checks before committing changes.
+- Use clear commit messages and small, focused pull requests.
+
+## Business Analysts (BA)
+- Capture requirements in Jira tickets with detailed acceptance criteria.
+- Keep documentation up to date and communicate scope changes promptly.
+
+## QA Engineers
+- Maintain automated and manual test cases.
+- Verify bug fixes and new features before they are merged.
+- Record defects with steps to reproduce and expected vs actual outcomes.
+
+## DevOps Engineers
+- Maintain and monitor CI/CD pipelines.
+- Manage environment variables and secrets securely.
+- Ensure logging and alerting are configured for all deployments.
+
+## Architects (Arq)
+- Review design proposals for scalability, security, and maintainability.
+- Keep architectural diagrams and documentation current.
+- Provide guidance on technology choices and system integration patterns.
+
+## Project Managers
+- Coordinate cross-team communication and track milestones.
+- Remove impediments and ensure risks are documented.
+
+## Product Owners
+- Prioritize backlog items and clarify feature goals.
+- Validate that delivered features provide business value.
+
+## UX/UI Designers
+- Deliver user flows and interface designs that align with product goals.
+- Collaborate with developers to ensure a consistent user experience.
+
+## Security
+- Perform periodic security reviews and dependency audits.
+- Flag and help remediate vulnerabilities promptly.
+
+## Support
+- Communicate user-reported issues to the team.
+- Document common problems and their resolutions for future reference.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md outlining responsibilities for developers, business analysts, QA, DevOps, architects, and other contributors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68912df759508328b5bc1e4ac9b12c2b